### PR TITLE
Made app.rb file as single point of entry for pub/sub service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,24 @@ q_it is a simple console based application that uses the AWS SQS service to publ
 Publishing messages with Q_IT
 
 ```
-> ruby app.rb <your-queue-name(required)> <delay_seconds(optional)>
+> ruby app.rb publish <your-queue-name(required)> <sleep_time_seconds(optional)>
 
 ```
+
 
 Subscribing to messages with Q_IT
 
 ```
-> ruby subscriber.rb <your-queue-url(required)> <wait-time-seconds(optional)>
+> ruby app.rb subscribe <your-queue-url(required)> <sleep_time_seconds(optional)>
 
 ```
+
+
+**sleep_time_seconds** - is the time in seconds between two consequtive send_message / receive_message calls made to the sqs server.
+
+
+While publishing to /subscribing from a queue it defaults to 5 seconds. 
+
+Acceptable values while **publishing** for sleep_time_seconds : Between 5-20 seconds.
+
+Acceptable values while **subscribing** for sleep_time_seconds : Between 3-15 seconds.

--- a/app.rb
+++ b/app.rb
@@ -1,16 +1,30 @@
 require 'rubygems'
 require 'bundler/setup'
-
-require 'byebug'
-
 require_relative 'publisher.rb'
+require_relative 'subscriber.rb'
 
-options = ARGV
-if options[0].nil?
-  puts "You must enter a queue name."
-  return 
+def run_service(options)
+  service = options.delete_at(0)
+  
+  case service
+  when 'publish'
+    publisher = Publisher.new(options)
+    publisher.start
+  when 'subscribe'
+    subscriber = Subscriber.new(options)
+    subscriber.start
+  else
+    puts "Invalid service name. Use 'publish' or 'subscribe'."
+    exit(1)
+  end
 end
-puts "Starting Queue Service..."
-sqs_pub = Publisher.new()    
-queue = sqs_pub.create_std_q(options[0])
-sqs_pub.publish_messages(queue.queue_url, options)
+
+# Beginning of execution of App.
+options = ARGV
+service = options[0]
+begin
+  puts "Starting Queue Service..."
+  run_service(options)
+rescue Exception => e
+  puts "There is an exception in the #{service} service #{e.inspect}"
+end

--- a/publisher.rb
+++ b/publisher.rb
@@ -24,7 +24,7 @@ class Publisher
 
   def publish_messages(queue_url)
     0.upto(Float::INFINITY) do |count|
-      message = { count: count, timestamp: Time.now.strftime("%GW%V%uT%H%M%S") }.to_json
+      message = { count: count, timestamp: Time.now.localtime.strftime("%F %T") }.to_json
       puts "Sending message - #{message}"
       sqs.send_message(queue_url: queue_url, message_body: message)
       sleep(sleep_period)

--- a/publisher.rb
+++ b/publisher.rb
@@ -3,16 +3,18 @@ require_relative 'load_aws'
 
 class Publisher
   
-  attr_reader :sqs
+  attr_reader :sqs, :sleep_period, :queue_name
 
-  def initialize
+  def initialize(options)
     creds = Aws::Credentials.new(AWS["access_key_id"], AWS["secret_access_key"])
     @sqs = Aws::SQS::Client.new(region: AWS["region"], credentials: creds)
+    @sleep_period = valid_sleep_period?(options[1]) ? options[1].to_i : 5
+    @queue_name = options[0]
   end
 
   # For Standard Queue
-  def create_std_q(queue_name)
-    std_queue = sqs.create_queue(queue_name: queue_name)
+  def create_std_q
+    sqs.create_queue(queue_name: queue_name)
   end
 
   def valid_sleep_period?(sleep_period)
@@ -20,14 +22,18 @@ class Publisher
     !sleep_period.nil? && sleep_period.match(max_sleep_period)
   end
 
-  def publish_messages(queue_url, options=[])
-    sleep_period = valid_sleep_period?(options[1]) ? options[1].to_i : 5
-    
+  def publish_messages(queue_url)
     0.upto(Float::INFINITY) do |count|
-      message = { count: count, timestamp: Time.now.strftime("%GW%V%uT%H%M%S%L%z") }.to_json
+      message = { count: count, timestamp: Time.now.strftime("%GW%V%uT%H%M%S") }.to_json
       puts "Sending message - #{message}"
       sqs.send_message(queue_url: queue_url, message_body: message)
       sleep(sleep_period)
     end
+  end
+
+  def start
+    queue = create_std_q
+    puts "Queue URL :: #{queue.queue_url}"
+    publish_messages(queue.queue_url)
   end
 end

--- a/subscriber.rb
+++ b/subscriber.rb
@@ -3,25 +3,23 @@ require_relative 'load_aws'
 
 class Subscriber
 
-  attr_reader :sqs
+  attr_reader :sqs, :sleep_period, :queue_url
 
-  def initialize
+  def initialize(options)
     creds = Aws::Credentials.new(AWS["access_key_id"], AWS["secret_access_key"])
     @sqs = Aws::SQS::Client.new(region: AWS["region"], credentials: creds)
+    @queue_url = options[0].chomp
+    @sleep_period = valid_sleep_period?(options[1]) ? options[1].to_i : 5
   end
 
   def valid_sleep_period?(sleep_period)
-    sleep_period = '2'
     max_sleep_period = /\A([3-9]|1[0-5])\z/
-    sleep_period.match?(max_sleep_period)
+    !sleep_period.nil? && sleep_period.match?(max_sleep_period)
   end
   
 
 # Todo: URL validation /\A(https:\/\/sqs.)#{AWS["region"]}.amazonaws.com\/\d{12}\/([a-zA-Z]*\d*[-_]*)+|(.fifo)\z/
-  def read_queue(options=[])
-    queue_url = options[0].chomp
-    sleep_period = valid_sleep_period?(options[1]) ? options[1].to_i : 5
-    
+  def read_queue
     loop do
       result = sqs.receive_message(queue_url: queue_url, max_number_of_messages: 1)
       
@@ -35,13 +33,8 @@ class Subscriber
       sleep(sleep_period)
     end
   end
-end
 
-begin
-  options = ARGV
-  puts "Starting Subscriber service..."
-  subscriber = Subscriber.new
-  subscriber.read_queue(options)
-rescue Exception => e
-  puts "There is an exception in the Subscriber service #{e.inspect}"
+  def start
+    read_queue
+  end
 end


### PR DESCRIPTION
This PR deals with consolidating the entry point of the service.

* _To run the publisher service use_ - 
`ruby app.rb publish <queue-name (required)> <sleep-time(optional)>`

**queue-name** - is the name you want to give to your standard queue.
**sleep-time** - is the time interval between two consecutive send_message calls.

* _To run the subscriber service use_ - 
`ruby app.rb subscribe <queue-url (required)> <sleep-time(optional)>`

**queue-url** - is the url of the queue from which you want to subscribe / receive messages.
**sleep-time** - is the time interval between two consecutive receive_message calls.
